### PR TITLE
Add moveit bridges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(tf2_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(trajectory_msgs REQUIRED)
+find_package(moveit_msgs REQUIRED)
+
 
 # find ROS 1 packages
 set(cmake_extras_files cmake/find_ros1_package.cmake cmake/find_ros1_interface_packages.cmake)
@@ -50,6 +52,7 @@ find_ros1_package(nav_msgs REQUIRED)
 find_ros1_package(sensor_msgs REQUIRED)
 find_ros1_package(geometry_msgs REQUIRED)
 find_ros1_package(trajectory_msgs REQUIRED)
+find_ros1_package(moveit_msgs REQUIRED)
 
 # find ROS 1 packages with messages / services
 include(cmake/find_ros1_interface_packages.cmake)
@@ -163,6 +166,7 @@ function(custom_executable target)
       "ros1_nav_msgs"
       "ros1_geometry_msgs"
       "ros1_trajectory_msgs"
+      "ros1_moveit_msgs"
       )
   endif()
   if(ARG_DEPENDENCIES)
@@ -210,7 +214,15 @@ custom_executable(jointstates_1_to_2 "src/jointstates_1_to_2.cpp"
 custom_executable(jointtrajectory_2_to_1 "src/jointtrajectory_2_to_1.cpp"
   ROS1_DEPENDENCIES
   TARGET_DEPENDENCIES "trajectory_msgs")
-
+custom_executable(pick_2_to_1 "src/pick_2_to_1.cpp"
+  ROS1_DEPENDENCIES
+  TARGET_DEPENDENCIES "moveit_msgs")
+custom_executable(place_2_to_1 "src/place_2_to_1.cpp"
+  ROS1_DEPENDENCIES
+  TARGET_DEPENDENCIES "moveit_msgs")
+custom_executable(moveit_result_1_to_2 "src/moveit_result_1_to_2.cpp"
+  ROS1_DEPENDENCIES
+  TARGET_DEPENDENCIES "moveit_msgs")
 custom_executable(simple_bridge "src/simple_bridge.cpp"
   ROS1_DEPENDENCIES
   TARGET_DEPENDENCIES "std_msgs")
@@ -231,6 +243,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "ros1_nav_msgs"
   "ros1_geometry_msgs"
   "ros1_trajectory_msgs"
+  "ros1_moveit_msgs"
   )
   
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})

--- a/launch/dedicated_bridges_launch.py
+++ b/launch/dedicated_bridges_launch.py
@@ -139,4 +139,37 @@ def generate_launch_description():
             ]
         ),
 
+        Node(
+            package='ros1_bridge',
+            node_executable='pick_2_to_1',
+            output='screen',
+            parameters=[],
+            remappings=[
+                ('input', 'moveit/pick'),
+                ('output', 'moveit/pick')
+            ]
+        ),
+
+        Node(
+            package='ros1_bridge',
+            node_executable='place_2_to_1',
+            output='screen',
+            parameters=[],
+            remappings=[
+                ('input', 'moveit/place'),
+                ('output', 'moveit/place')
+            ]
+        ),
+
+        Node(
+            package='ros1_bridge',
+            node_executable='moveit_result_1_to_2',
+            output='screen',
+            parameters=[],
+            remappings=[
+                ('input', 'moveit/result'),
+                ('output', 'moveit/result')
+            ]
+        ),
+
     ])

--- a/src/moveit_result_1_to_2.cpp
+++ b/src/moveit_result_1_to_2.cpp
@@ -37,9 +37,6 @@ rclcpp::Publisher<moveit_msgs::msg::MoveItErrorCodes>::SharedPtr pub;
 
 void moveitResultCallback(boost::shared_ptr<moveit_msgs::MoveItErrorCodes> ros1_msg)
 {
-  if (pub->get_subscription_count() == 0)
-    return;
-
   auto ros2_msg = std::make_unique<moveit_msgs::msg::MoveItErrorCodes>();
 
   ros2_msg->val = ros1_msg->val;
@@ -52,7 +49,7 @@ int main(int argc, char * argv[])
   // ROS 2 node and publisher
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("moveit_result_1_to_2");
-  pub = node->create_publisher<moveit_msgs::msg::MoveItErrorCodes>("output", rclcpp::QoS(100).keep_all().transient_local());
+  pub = node->create_publisher<moveit_msgs::msg::MoveItErrorCodes>("output", 1);
 
   // ROS 1 node and subscriber
   ros::init(argc, argv, "moveit_result_1_to_2");

--- a/src/moveit_result_1_to_2.cpp
+++ b/src/moveit_result_1_to_2.cpp
@@ -1,0 +1,67 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+// include ROS 1
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include "ros/ros.h"
+#include "moveit_msgs/MoveItErrorCodes.h"
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+
+// include ROS 2
+#include "rclcpp/rclcpp.hpp"
+#include "moveit_msgs/msg/move_it_error_codes.hpp"
+
+
+rclcpp::Publisher<moveit_msgs::msg::MoveItErrorCodes>::SharedPtr pub;
+
+
+void moveitResultCallback(boost::shared_ptr<moveit_msgs::MoveItErrorCodes> ros1_msg)
+{
+  if (pub->get_subscription_count() == 0)
+    return;
+
+  auto ros2_msg = std::make_unique<moveit_msgs::msg::MoveItErrorCodes>();
+
+  ros2_msg->val = ros1_msg->val;
+
+  pub->publish(std::move(ros2_msg));
+}
+
+int main(int argc, char * argv[])
+{
+  // ROS 2 node and publisher
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("moveit_result_1_to_2");
+  pub = node->create_publisher<moveit_msgs::msg::MoveItErrorCodes>("output", rclcpp::QoS(100).keep_all().transient_local());
+
+  // ROS 1 node and subscriber
+  ros::init(argc, argv, "moveit_result_1_to_2");
+  ros::NodeHandle n;
+  ros::Subscriber sub = n.subscribe("input", 100, moveitResultCallback);
+
+  ros::spin();
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/src/pick_2_to_1.cpp
+++ b/src/pick_2_to_1.cpp
@@ -34,9 +34,6 @@ ros::Publisher pub;
 
 void pickCallback(const moveit_msgs::msg::Grasp::SharedPtr ros2_msg)
 {
-  if (pub.getNumSubscribers() == 0)
-    return;
-
   moveit_msgs::Grasp ros1_msg;
   ros1_msg.id = ros2_msg->id;
   ros1_msg.grasp_pose.header.frame_id = ros2_msg->grasp_pose.header.frame_id;
@@ -59,13 +56,13 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("pick_2_to_1");
   auto sub = node->create_subscription<moveit_msgs::msg::Grasp>(
-    "input", 100, pickCallback);
+    "input", 1, pickCallback);
 
 
   // ROS 1 node and publisher
   ros::init(argc, argv, "pick_2_to_1");
   ros::NodeHandle n;
-  pub = n.advertise<moveit_msgs::Grasp>("output", 100);
+  pub = n.advertise<moveit_msgs::Grasp>("output", 1);
 
   rclcpp::spin(node);
 

--- a/src/pick_2_to_1.cpp
+++ b/src/pick_2_to_1.cpp
@@ -1,0 +1,75 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+// include ROS 1
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include "ros/ros.h"
+#include "moveit_msgs/Grasp.h"
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+
+// include ROS 2
+#include "rclcpp/rclcpp.hpp"
+#include "moveit_msgs/msg/grasp.hpp"
+
+
+ros::Publisher pub;
+
+void pickCallback(const moveit_msgs::msg::Grasp::SharedPtr ros2_msg)
+{
+  if (pub.getNumSubscribers() == 0)
+    return;
+
+  moveit_msgs::Grasp ros1_msg;
+  ros1_msg.id = ros2_msg->id;
+  ros1_msg.grasp_pose.header.frame_id = ros2_msg->grasp_pose.header.frame_id;
+  ros1_msg.grasp_pose.header.stamp.sec = ros2_msg->grasp_pose.header.stamp.sec;
+  ros1_msg.grasp_pose.header.stamp.nsec = ros2_msg->grasp_pose.header.stamp.nanosec;
+  ros1_msg.grasp_pose.pose.position.x = ros2_msg->grasp_pose.pose.position.x;
+  ros1_msg.grasp_pose.pose.position.y = ros2_msg->grasp_pose.pose.position.y;
+  ros1_msg.grasp_pose.pose.position.z = ros2_msg->grasp_pose.pose.position.z;
+  ros1_msg.grasp_pose.pose.orientation.x = ros2_msg->grasp_pose.pose.orientation.x;
+  ros1_msg.grasp_pose.pose.orientation.y = ros2_msg->grasp_pose.pose.orientation.y;
+  ros1_msg.grasp_pose.pose.orientation.z = ros2_msg->grasp_pose.pose.orientation.z;
+  ros1_msg.grasp_pose.pose.orientation.w = ros2_msg->grasp_pose.pose.orientation.w;
+  
+  pub.publish(ros1_msg);
+}
+
+int main(int argc, char * argv[])
+{
+  // ROS 2 node and subscriber
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("pick_2_to_1");
+  auto sub = node->create_subscription<moveit_msgs::msg::Grasp>(
+    "input", 100, pickCallback);
+
+
+  // ROS 1 node and publisher
+  ros::init(argc, argv, "pick_2_to_1");
+  ros::NodeHandle n;
+  pub = n.advertise<moveit_msgs::Grasp>("output", 100);
+
+  rclcpp::spin(node);
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/src/place_2_to_1.cpp
+++ b/src/place_2_to_1.cpp
@@ -1,0 +1,75 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+// include ROS 1
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include "ros/ros.h"
+#include "moveit_msgs/PlaceLocation.h"
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
+
+// include ROS 2
+#include "rclcpp/rclcpp.hpp"
+#include "moveit_msgs/msg/place_location.hpp"
+
+
+ros::Publisher pub;
+
+void placeCallback(const moveit_msgs::msg::PlaceLocation::SharedPtr ros2_msg)
+{
+  if (pub.getNumSubscribers() == 0)
+    return;
+
+  moveit_msgs::PlaceLocation ros1_msg;
+  ros1_msg.id = ros2_msg->id;
+  ros1_msg.place_pose.header.frame_id = ros2_msg->place_pose.header.frame_id;
+  ros1_msg.place_pose.header.stamp.sec = ros2_msg->place_pose.header.stamp.sec;
+  ros1_msg.place_pose.header.stamp.nsec = ros2_msg->place_pose.header.stamp.nanosec;
+  ros1_msg.place_pose.pose.position.x = ros2_msg->place_pose.pose.position.x;
+  ros1_msg.place_pose.pose.position.y = ros2_msg->place_pose.pose.position.y;
+  ros1_msg.place_pose.pose.position.z = ros2_msg->place_pose.pose.position.z;
+  ros1_msg.place_pose.pose.orientation.x = ros2_msg->place_pose.pose.orientation.x;
+  ros1_msg.place_pose.pose.orientation.y = ros2_msg->place_pose.pose.orientation.y;
+  ros1_msg.place_pose.pose.orientation.z = ros2_msg->place_pose.pose.orientation.z;
+  ros1_msg.place_pose.pose.orientation.w = ros2_msg->place_pose.pose.orientation.w;
+  
+  pub.publish(ros1_msg);
+}
+
+int main(int argc, char * argv[])
+{
+  // ROS 2 node and subscriber
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("place_2_to_1");
+  auto sub = node->create_subscription<moveit_msgs::msg::PlaceLocation>(
+    "input", 100, placeCallback);
+
+
+  // ROS 1 node and publisher
+  ros::init(argc, argv, "place_2_to_1");
+  ros::NodeHandle n;
+  pub = n.advertise<moveit_msgs::PlaceLocation>("output", 100);
+
+  rclcpp::spin(node);
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/src/place_2_to_1.cpp
+++ b/src/place_2_to_1.cpp
@@ -34,9 +34,6 @@ ros::Publisher pub;
 
 void placeCallback(const moveit_msgs::msg::PlaceLocation::SharedPtr ros2_msg)
 {
-  if (pub.getNumSubscribers() == 0)
-    return;
-
   moveit_msgs::PlaceLocation ros1_msg;
   ros1_msg.id = ros2_msg->id;
   ros1_msg.place_pose.header.frame_id = ros2_msg->place_pose.header.frame_id;
@@ -59,13 +56,13 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("place_2_to_1");
   auto sub = node->create_subscription<moveit_msgs::msg::PlaceLocation>(
-    "input", 100, placeCallback);
+    "input", 1, placeCallback);
 
 
   // ROS 1 node and publisher
   ros::init(argc, argv, "place_2_to_1");
   ros::NodeHandle n;
-  pub = n.advertise<moveit_msgs::PlaceLocation>("output", 100);
+  pub = n.advertise<moveit_msgs::PlaceLocation>("output", 1);
 
   rclcpp::spin(node);
 


### PR DESCRIPTION
Hi @fmrico 

This PR contains three new bridges for moveit_msgs/msg/Gras, moveit_msgs/msg/PlaceLocation and moveit_msgs/msg/MoveItErrorCodes. They are necessary to command moveit from ROS2.

A has also added 3 entries in the launcher.

I hope it helps !!